### PR TITLE
refactor sql_query_function

### DIFF
--- a/project/app/sql_query_function.py
+++ b/project/app/sql_query_function.py
@@ -6,13 +6,13 @@ from dotenv import load_dotenv
 # Load environment variables from .env
 load_dotenv()
 
-
-def fetch_query(query, columns):
+def fetch_query_records(query, columns):
     """
-    Creates a connection to database, returns query from specified table
-    as a list of dictionaries.
+    Creates a connection to database, returns query from specified table.
 
     Input: query: a SQL query (string)
+
+    Returns: response: cursos.fetchall() object in array form
     """
     DB_NAME = os.getenv("DB_NAME")
     DB_USER = os.getenv("DB_USER")
@@ -27,19 +27,35 @@ def fetch_query(query, columns):
         host=DB_HOST)
     # Creating Cursor Object
     cursor = conn.cursor()
-    # Fetch comments query
+    # Fetch query
     query = query
     # Execute query
     cursor.execute(query)
     # Query results
-    comments = list(cursor.fetchall())
+    response = list(cursor.fetchall())
+    # Closing Connection
+    conn.close()
+
+    return response
+
+def fetch_query(query, columns):
+    """
+    Creates a connection to database, returns query from specified table
+    as a list of dictionaries.
+
+    Input: query: a SQL query (string)
+
+    Returns: pairs: dataframe of cursor.fetchall() response in JSON pairs
+    """
+    
+    # Fetch query
+    response = fetch_query_records(query, columns)
+
     # Key-value pair names for df columns
     columns = columns
     # List of tuples to DF
-    df = pd.DataFrame(comments, columns=columns)
+    df = pd.DataFrame(response, columns=columns)
     # DF to dictionary
     pairs = df.to_json(orient='records')
-    # Closing Connection
-    conn.close()
 
     return pairs


### PR DESCRIPTION
Adds additional function - `fetch_query_records` - which returns `cursor.fetchall()` object as an array, rather than JSON pairs

Retains `fetch_query` function with the previous usage, but refactored to call on `fetch_query_records` function