### PR TITLE
Updates to bls_viz

### DIFF
--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "DOCKER_ID/labs26-citrics-ds-teama_web:latest",
+    "Name": "ekselan/labs26-citrics-ds-teama_web:latest",
     "Update": "true"
   },
   "Ports": [

--- a/Dockerrun.aws.json
+++ b/Dockerrun.aws.json
@@ -1,7 +1,7 @@
 {
   "AWSEBDockerrunVersion": "1",
   "Image": {
-    "Name": "ekselan/labs26-citrics-ds-teama_web:latest",
+    "Name": "DOCKER_ID/labs26-citrics-ds-teama_web:latest",
     "Update": "true"
   },
   "Ports": [

--- a/project/app/api/bls_viz.py
+++ b/project/app/api/bls_viz.py
@@ -82,20 +82,24 @@ async def bls_viz(city: str, statecode: str):
     )
 
     # Set Title
-    styling['title'] = f'The mot prevelant job in {city}, {statecode} is {sub["occ_title"][0]} with an average annual salary of {sub["annual_wage"][0]}'
+    styling["title"] = "Hover over bars for Job Industry"
+
+    x = sub["occ_title"]
+    y= sub["annual_wage"]
 
     fig = go.Figure(data=go.Bar(name=f'{city}, {statecode}',
-                            x=sub['occ_title'],
-                            y=sub['annual_wage'],
-                            marker_color=styling.get('city1color')),
-                            layout=layout)
+                                x=x,
+                                y=y,
+                                marker=dict(color=y, colorscale="greens")),
+                                layout=layout)
 
     fig.update_layout(barmode='group', title_text=styling.get('title'),
-                        xaxis_title='Occupational Title',
-                        yaxis_title='Average Annual Salary',
-                        font=dict(family='Open Sans, extra bold', size=10),
-                        height=412,
-                        width=640)
-                        # legend_title='Cities')
+                    xaxis_title='10 Most Prevelant Jobs (left to right, descending)',
+                    yaxis_title='Average Annual Salary',
+                    font=dict(family='Open Sans, extra bold', size=10),
+                    height=412,
+                    width=640)
+
+    fig.update_xaxes(showticklabels=False) # hide all the xticks
 
     return fig.to_json()

--- a/project/app/api/bls_viz_view.py
+++ b/project/app/api/bls_viz_view.py
@@ -85,22 +85,25 @@ async def bls_viz(city: str, statecode: str):
     )
 
     # Set Title
-    styling['title'] = f'The mot prevelant job in {city}, {statecode} is {sub["occ_title"][0]} with an average annual salary of {sub["annual_wage"][0]}'
+    styling["title"] = "Hover over bars for Job Industry"
+
+    x = sub["occ_title"]
+    y= sub["annual_wage"]
 
     fig = go.Figure(data=go.Bar(name=f'{city}, {statecode}',
-                            x=sub['occ_title'],
-                            y=sub['annual_wage'],
-                            marker_color=styling.get('city1color')),
-                            layout=layout)
-
+                                x=x,
+                                y=y,
+                                marker=dict(color=y, colorscale="greens")),
+                                layout=layout)
 
     fig.update_layout(barmode='group', title_text=styling.get('title'),
-                        xaxis_title='Occupational Title',
-                        yaxis_title='Average Annual Salary',
-                        font=dict(family='Open Sans, extra bold', size=10),
-                        height=412,
-                        width=640)
-                        # legend_title='Cities')
+                    xaxis_title='10 Most Prevelant Jobs (left to right, descending)',
+                    yaxis_title='Average Annual Salary',
+                    font=dict(family='Open Sans, extra bold', size=10),
+                    height=412,
+                    width=640)
+
+    fig.update_xaxes(showticklabels=False) # hide all the xticks
 
     img = fig.to_image(format="png")
 

--- a/project/app/main.py
+++ b/project/app/main.py
@@ -25,7 +25,7 @@ DESC_TEXT = "Finding a place to live is hard! Nomads struggle with finding the r
 app = FastAPI(
     title='Citrics API',
     description=DESC_TEXT,
-    version='1.9',
+    version='2.0',
     docs_url='/',
 )
 


### PR DESCRIPTION
Addresses requests from web team for `bls_viz`

- Color scale: based on annual wage
- Title: usage instruction rather than industry info
- Xticks: remove to save space/cleanup rendering on front end
- Xlabel: convey ordering/job industry insight